### PR TITLE
Use qtcontacts-sqlite engine by default

### DIFF
--- a/50-nemo-mobile-ui.conf
+++ b/50-nemo-mobile-ui.conf
@@ -12,6 +12,9 @@ QT_DEFAULT_RUNTIME_SYSTEM=meego
 #Use maliit VKB
 QT_IM_MODULE=Maliit
 
+# Use qtcontacts-sqlite engine by default, if possible
+QTCONTACTS_MANAGER_OVERRIDE=org.nemomobile.contacts.sqlite
+
 #Don't use window decorations
 M_DECORATED=0
 


### PR DESCRIPTION
If the qtcontacts-sqlite (org.nemomobile.contacts.sqlite) plugin for
QtMobility Contacts API exists, it should be used by default.
A recent patch to QtMobility adds support for enabling overriding the
platform default manager engine via the QTCONTACTS_MANAGER_OVERRIDE
environment variable.
